### PR TITLE
Accept negative values

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = postcss.plugin('postcss-custom-unit', function(opts) {
             }
 
             opts.units.forEach(function (unit) {
-                var reg = new RegExp('(([\\d\.]+)' + unit.from + ')', 'g');
+                var reg = new RegExp('(([-\\d\.]+)' + unit.from + ')', 'g');
                 decl.value = decl.value.replace(reg, function (match, p1, p2) {
                     return unit.convert(p2);
                 });


### PR DESCRIPTION
A very small edit to your Regex to allow negative values to be correctly parsed by this plugin. Currently, a value like `-1` will be read as `1` which is probably not what the user wants.

This change is fully backwards-compatible.